### PR TITLE
Hotfix: Fix for curl: (35) error:141A318A:SSL routines:tls_process_ske_dhe:dh key too small

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,5 @@
 FROM php:7.2-apache
+
 RUN apt-get update && apt-get install --no-install-recommends -y gnupg && apt-key update -y
 RUN apt-get install --no-install-recommends -y automake \
     bash \
@@ -29,6 +30,9 @@ RUN apt-get install --no-install-recommends -y automake \
     zlib1g-dev \
     g++ \
     vim
+
+# Make sure we're using the right security level so things don't break
+RUN vi -c '%s/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf -c 'wq' 
 
 # Enable Apache Extensions We Need
 RUN a2enmod proxy \
@@ -61,7 +65,6 @@ RUN pip install awscli && ln -s /usr/local/bin/aws /usr/bin/aws
 RUN curl -sL https://deb.nodesource.com/setup_11.x  | bash && apt-get install --no-install-recommends -y nodejs && npm install -g gulp bower
 
 # Install git lfs
-
 RUN wget https://github.com/git/git/archive/v2.21.0.zip -O git.zip && \
     unzip git.zip && \
     cd git-* && \

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get install --no-install-recommends -y curl \
     g++ \
     && rm -rf /var/lib/apt/lists/* # cleanup caches when we're done
 
+# Make sure we're using the right security level so things don't break
+RUN vi -c '%s/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf -c 'wq' 
+
 # Enable Apache Extensions We Need
 RUN a2enmod proxy \
     proxy_ajp \


### PR DESCRIPTION
After image was upgraded we got a new version of SSL which defaults the security level to 2, this rejects SSL keys which are too small. For now we will force Security Level 1

Further reading:
https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html
https://access.redhat.com/articles/3642912